### PR TITLE
Update createSupport.sqf

### DIFF
--- a/support/createSupport.sqf
+++ b/support/createSupport.sqf
@@ -10,6 +10,8 @@
 private _index = _this select 0;
 private _thisVehicle = _this select 1;
 
+//schnellste lösung. nicht die beste.
+if (!canmove _thisVehicle) exitwith {};
 
 private _spawnPos = getposATL _thisVehicle;
 _spawnPos set [2,(_spawnPos select 2) - 8];


### PR DESCRIPTION
Support script bricht jetzt ab, wenn _thisVehicle nicht mehr Flugtauglich ist, also abstürzt oder tot ist